### PR TITLE
Remove AWS CLI setup file since it was documented in the first setup step

### DIFF
--- a/workshop-notes/03-project-work/03.2-aws-cli-setup/notes.md
+++ b/workshop-notes/03-project-work/03.2-aws-cli-setup/notes.md
@@ -1,1 +1,0 @@
-Talk about the difference in sm and ssm.


### PR DESCRIPTION
This PR is removing AWS CLI step since I documented it in the initial setup already